### PR TITLE
Return items without selections onBlur()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,12 @@ const setup = ({customTextFormattings} = {}) => {
         onUpdate({items, selectionBoundingClientRect, activeItem});
       };
 
-      const events = setupEvents(eventhandler, getCustomKeyDown);
+      const onBlur = ({delegateTarget: articleContainer}) => {
+        const items = htmlToArticleJson(articleContainer);
+        onUpdate({items});
+      };
+
+      const events = objectAssign({onBlur}, setupEvents(eventhandler, getCustomKeyDown));
       const articleProps = objectAssign({contenteditable: 'true'}, events);
       return <Article items={[]} contenteditable='true' articleProps={articleProps} />;
     },

--- a/lib/setup-events.js
+++ b/lib/setup-events.js
@@ -22,8 +22,7 @@ export default function setupEvents (cb, getCustomKeyDown = () => {}) {
 
   const onCut = callbackNextTick;
   const onPaste = callbackNextTick;
-  const onBlur = callback;
   const onMouseUp = callback;
 
-  return {onKeyDown, onPaste, onCut, onBlur, onMouseUp};
+  return {onKeyDown, onPaste, onCut, onMouseUp};
 }


### PR DESCRIPTION
Type: Major
Review: @iefserge @danmakenoise 

Adds special case for onBlur event, not saving selection. Fixes so that it's possible to focus on elements outside of the editor, before this fix the editor would always be restoring the selection and focus on every render. 