### PR TITLE
Embed fixes

### DIFF
--- a/example/client.js
+++ b/example/client.js
@@ -6,7 +6,7 @@ const Article = setupArticle();
 const container = document.querySelector('#editor');
 
 const items = [{
-  'type': 'paragraph',
+  'type': 'header1',
   'children': [{
     'type': 'text',
     'content': 'Text text text',
@@ -42,6 +42,17 @@ const items = [{
   'caption': [],
   'id': 'iHTTDHz6Z2v',
   'url': 'https://vine.co/v/iHTTDHz6Z2v/embed/simple'
+}, {
+  'type': 'header1',
+  'children': [{
+    'type': 'text',
+    'content': 'Text text text',
+    'href': null,
+    'italic': false,
+    'bold': false,
+    'mark': false,
+    'markClass': null
+  }]
 }, {
   'type': 'embed',
   'embedType': 'youtube',

--- a/lib/embeds/facebook.js
+++ b/lib/embeds/facebook.js
@@ -5,8 +5,8 @@ import renderEmbedIframe from './render-embed-iframe';
 
 export default {
   name: 'FacebookEmbed',
-  render: function ({props: {id}}) {
-    return renderEmbedIframe({id, type: 'facebook'});
+  render: function ({props: {url}}) {
+    return renderEmbedIframe({url, type: 'facebook'});
   },
   afterMount: function ({props}, iframe) {
     iframe.__props__ = props;

--- a/lib/embeds/render-embed-iframe.js
+++ b/lib/embeds/render-embed-iframe.js
@@ -1,5 +1,6 @@
 import element from 'magic-virtual-element';
 
-export default ({id, type}) => {
-  return (<iframe id={`${type}-${id}`} type={`${type}`} frameBorder='0' width='100%' src='javascript:false'></iframe>);
+export default ({id, url = '', type}) => {
+  const embedId = id || url.replace(/https:\/\/[^\/]*\//, '');
+  return (<iframe id={`${type}-${embedId}`} type={`${type}`} frameBorder='0' width='100%' src='javascript:false'></iframe>);
 };

--- a/lib/embeds/render-embed-iframe.js
+++ b/lib/embeds/render-embed-iframe.js
@@ -1,6 +1,6 @@
 import element from 'magic-virtual-element';
 
 export default ({id, url = '', type}) => {
-  const embedId = id || url.replace(/https:\/\/[^\/]*\//, '');
+  const embedId = id || url.replace(/https:\/\/[^\/]*\//, '').replace(/\W+/g, '');
   return (<iframe id={`${type}-${embedId}`} type={`${type}`} frameBorder='0' width='100%' src='javascript:false'></iframe>);
 };

--- a/lib/embeds/tumblr.js
+++ b/lib/embeds/tumblr.js
@@ -5,8 +5,8 @@ import renderEmbedIframe from './render-embed-iframe';
 
 export default {
   name: 'TumblrEmbed',
-  render: ({props: {id}}) => {
-    return renderEmbedIframe({id, type: 'tumblr'});
+  render: ({props: {url}}) => {
+    return renderEmbedIframe({url, type: 'tumblr'});
   },
   afterMount: ({props}, iframe) => {
     iframe.__props__ = props;

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ import getIndexAndRectOfActiveEditorBlock from './get-index-and-rect-of-active-e
 import {map} from 'immutable-array-methods';
 import {setIn} from 'immutable-object-methods';
 import objectAssign from 'object-assign';
-import diff, {CREATE, UPDATE, MOVE, REMOVE} from 'dift';
+import patchDom from './patch-dom';
 
 function parseEmbed (type) {
   return (elm) => {
@@ -89,35 +89,7 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
       assert(oldArticleElm, 'oldArticleElm must exists');
       assert(newArticleElm, 'newArticleElm must exists');
 
-      const newList = Array.from(newArticleElm.childNodes);
-      const oldList = Array.from(oldArticleElm.childNodes);
-      diff(oldList, newList, (type, prev, next, pos) => {
-        switch (type) {
-          case CREATE:
-            if (next) {
-              oldArticleElm.insertBefore(next, oldArticleElm.childNodes[pos] || null);
-            }
-            break;
-          case UPDATE:
-            // we never end up here since equality for us means that things are equal
-            break;
-          case MOVE:
-            // TODO: Implement move
-            break;
-          case REMOVE:
-            if (prev && prev.remove) {
-              prev.remove();
-            }
-            break;
-        }
-      }, (elm) => {
-        if (elm.tagName.toLowerCase() === 'figure' && elm.querySelector('iframe')) {
-          // TODO: Handle if caption has changed, we should prob handle that in update (above)
-          return elm.querySelector('iframe').id;
-        }
-
-        return elm.outerHTML;
-      });
+      patchDom({oldArticleElm, newArticleElm});
 
       if (selections) {
         restoreSelection(oldArticleElm);

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@
 import {render, tree} from 'deku';
 import element from 'magic-virtual-element';
 import {save as saveSelection, restore as restoreSelection} from 'save-selection';
-import morphdom from 'morphdom';
 import setupHtmlToArticleJson from 'html-to-article-json';
 import assert from 'assert';
 import setupArticle from 'article-json-html-render';
@@ -15,6 +14,7 @@ import getIndexAndRectOfActiveEditorBlock from './get-index-and-rect-of-active-e
 import {map} from 'immutable-array-methods';
 import {setIn} from 'immutable-object-methods';
 import objectAssign from 'object-assign';
+import diff, {CREATE, UPDATE, MOVE, REMOVE} from 'dift';
 
 function parseEmbed (type) {
   return (elm) => {
@@ -89,12 +89,34 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
       assert(oldArticleElm, 'oldArticleElm must exists');
       assert(newArticleElm, 'newArticleElm must exists');
 
-      morphdom(oldArticleElm, newArticleElm, {
-        childrenOnly: true,
-        onBeforeElUpdated: function (fromEl, toEl) {
-          return fromEl.tagName.toLowerCase() !== 'iframe' ||
-            fromEl.src !== toEl.src;
+      const newList = Array.from(newArticleElm.childNodes);
+      const oldList = Array.from(oldArticleElm.childNodes);
+      diff(oldList, newList, (type, prev, next, pos) => {
+        switch (type) {
+          case CREATE:
+            if (next) {
+              oldArticleElm.insertBefore(next, oldArticleElm.childNodes[pos] || null);
+            }
+            break;
+          case UPDATE:
+            // we never end up here since equality for us means that things are equal
+            break;
+          case MOVE:
+            // TODO: Implement move
+            break;
+          case REMOVE:
+            if (prev && prev.remove) {
+              prev.remove();
+            }
+            break;
         }
+      }, (elm) => {
+        if (elm.tagName.toLowerCase() === 'figure' && elm.querySelector('iframe')) {
+          // TODO: Handle if caption has changed, we should prob handle that in update (above)
+          return elm.querySelector('iframe').id;
+        }
+
+        return elm.outerHTML;
       });
 
       if (selections) {

--- a/lib/patch-dom.js
+++ b/lib/patch-dom.js
@@ -31,7 +31,8 @@ const updateIframeEmbed = ({oldFigure, newFigure}) => {
 
 const getKey = (elm) => {
   if (isIframeEmbed(elm)) {
-    return elm.querySelector('iframe').id;
+    const iframe = elm.querySelector('iframe');
+    return iframe.src !== 'javascript:false' ? iframe.src : iframe.id;
   }
 
   return elm.outerHTML;

--- a/lib/patch-dom.js
+++ b/lib/patch-dom.js
@@ -1,0 +1,38 @@
+import diff, {CREATE, UPDATE, MOVE, REMOVE} from 'dift';
+
+const getKey = (elm) => {
+  if (elm.tagName.toLowerCase() === 'figure' && elm.querySelector('iframe')) {
+    // TODO: Handle if caption has changed, we should prob handle that in update (above)
+    return elm.querySelector('iframe').id;
+  }
+
+  return elm.outerHTML;
+};
+
+export default ({oldArticleElm, newArticleElm}) => {
+  const newList = Array.from(newArticleElm.childNodes);
+  const oldList = Array.from(oldArticleElm.childNodes);
+
+  const patch = (type, prev, next, pos) => {
+    switch (type) {
+      case CREATE:
+        if (next) {
+          oldArticleElm.insertBefore(next, oldArticleElm.childNodes[pos] || null);
+        }
+        break;
+      case UPDATE:
+        // we never end up here since equality for us means that things are equal
+        break;
+      case MOVE:
+        // TODO: Implement move
+        break;
+      case REMOVE:
+        if (prev && prev.remove) {
+          prev.remove();
+        }
+        break;
+    }
+  };
+
+  diff(oldList, newList, patch, getKey);
+};

--- a/lib/patch-dom.js
+++ b/lib/patch-dom.js
@@ -1,8 +1,27 @@
 import diff, {CREATE, UPDATE, MOVE, REMOVE} from 'dift';
 
+const isIframeEmbed = (elm) => elm && elm.tagName &&
+  elm.tagName.toLowerCase() === 'figure' && elm.querySelector('iframe');
+
+const updateIframeEmbed = ({oldFigure, newFigure}) => {
+  // We need to update the figure without touching the iframe
+  // to avoid reloading it for every update.
+  const oldCaption = oldFigure.querySelector('figcaption');
+  const newCaption = newFigure.querySelector('figcaption');
+
+  if (oldCaption && newCaption) {
+    oldFigure.replaceChild(newCaption, oldCaption);
+  } else if (oldCaption) {
+    oldFigure.removeChild(oldCaption);
+  } else if (newCaption) {
+    oldFigure.appendChild(newCaption);
+  }
+
+  // TODO: Update figure attributes.
+};
+
 const getKey = (elm) => {
-  if (elm.tagName.toLowerCase() === 'figure' && elm.querySelector('iframe')) {
-    // TODO: Handle if caption has changed, we should prob handle that in update (above)
+  if (isIframeEmbed(elm)) {
     return elm.querySelector('iframe').id;
   }
 
@@ -21,7 +40,12 @@ export default ({oldArticleElm, newArticleElm}) => {
         }
         break;
       case UPDATE:
-        // we never end up here since equality for us means that things are equal
+        if (isIframeEmbed(prev)) {
+          updateIframeEmbed({
+            oldFigure: oldArticleElm.childNodes[pos],
+            newFigure: next
+          });
+        }
         break;
       case MOVE:
         oldArticleElm.insertBefore(next, oldArticleElm.childNodes[pos]);

--- a/lib/patch-dom.js
+++ b/lib/patch-dom.js
@@ -4,6 +4,10 @@ const isIframeEmbed = (elm) => elm && elm.tagName &&
   elm.tagName.toLowerCase() === 'figure' && elm.querySelector('iframe');
 
 const updateIframeEmbed = ({oldFigure, newFigure}) => {
+  if (!oldFigure || !newFigure) {
+    console.error('missing old or new figure', {oldFigure, newFigure});
+    return;
+  }
   // We need to update the figure without touching the iframe
   // to avoid reloading it for every update.
   const oldCaption = oldFigure.querySelector('figcaption');
@@ -41,33 +45,55 @@ const getKey = (elm) => {
 export default ({oldArticleElm, newArticleElm}) => {
   const newList = Array.from(newArticleElm.childNodes);
   const oldList = Array.from(oldArticleElm.childNodes);
+  const queue = {
+    create: [],
+    update: [],
+    remove: [],
+    move: []
+  };
 
   const patch = (type, prev, next, pos) => {
     switch (type) {
       case CREATE:
         if (next) {
-          oldArticleElm.insertBefore(next, oldArticleElm.childNodes[pos] || null);
+          queue.create.push(() => oldArticleElm.insertBefore(
+            next, oldArticleElm.childNodes[pos] || null));
         }
         break;
       case UPDATE:
         if (isIframeEmbed(prev)) {
-          updateIframeEmbed({
+          queue.update.push(() => updateIframeEmbed({
             oldFigure: oldArticleElm.childNodes[pos],
             newFigure: next
-          });
+          }));
         }
         break;
       case MOVE:
-        oldArticleElm.insertBefore(next, oldArticleElm.childNodes[pos]);
-        prev.remove();
+        queue.move.push(() => {
+          // it's already in the right position - can happen if we had a previous
+          // move which moved things around
+          if (prev === oldArticleElm.childNodes[pos]) {
+            return;
+          }
+
+          oldArticleElm.insertBefore(prev, oldArticleElm.childNodes[pos]);
+        });
         break;
       case REMOVE:
         if (prev && prev.remove) {
-          prev.remove();
+          queue.remove.push(() => {
+            prev.remove();
+          });
         }
         break;
     }
   };
 
   diff(oldList, newList, patch, getKey);
+  // Rearrange the order in which these updates are run,
+  // doing removes before moves to avoid unnecessary moves.
+  queue.create.forEach(fn => fn());
+  queue.remove.forEach(fn => fn());
+  queue.move.forEach(fn => fn());
+  queue.update.forEach(fn => fn());
 };

--- a/lib/patch-dom.js
+++ b/lib/patch-dom.js
@@ -17,7 +17,16 @@ const updateIframeEmbed = ({oldFigure, newFigure}) => {
     oldFigure.appendChild(newCaption);
   }
 
-  // TODO: Update figure attributes.
+  const oldAttributes = Array.from(oldFigure.attributes);
+  const newAttributes = Array.from(newFigure.attributes);
+
+  oldAttributes.forEach(({name}) => {
+    oldFigure.removeAttribute(name);
+  });
+
+  newAttributes.forEach(({name, value}) => {
+    oldFigure.setAttribute(name, value);
+  });
 };
 
 const getKey = (elm) => {

--- a/lib/patch-dom.js
+++ b/lib/patch-dom.js
@@ -24,7 +24,8 @@ export default ({oldArticleElm, newArticleElm}) => {
         // we never end up here since equality for us means that things are equal
         break;
       case MOVE:
-        // TODO: Implement move
+        oldArticleElm.insertBefore(next, oldArticleElm.childNodes[pos]);
+        prev.remove();
         break;
       case REMOVE:
         if (prev && prev.remove) {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "article-json-html-render": "^2.5.0",
     "deku": "^1.0.0",
+    "dift": "^0.1.12",
     "embeds": "^2.5.1",
     "get-selection-range-from-elm": "^2.0.1",
     "html-to-article-json": "^1.12.4",
@@ -53,7 +54,6 @@
     "is-url": "^1.2.1",
     "keycode": "^2.1.1",
     "magic-virtual-element": "^1.0.6",
-    "morphdom": "^2.0.0",
     "object-assign": "^4.1.0",
     "save-selection": "^2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "create-event": "^1.0.9",
     "electron-prebuilt": "^0.37.7",
     "faucet": "0.0.1",
+    "pretty": "^1.0.0",
     "semistandard-deku": "github:micnews/semistandard#deku",
     "snazzy": "^5.0.0",
     "tape": "^4.5.1",

--- a/test/embeds-test.js
+++ b/test/embeds-test.js
@@ -24,7 +24,7 @@ const test = process.browser ? _test : function () {};
 test('FacebookEmbed - body', t => {
   const actual = renderString(tree(<FacebookEmbed embedAs='post' url='https://www.facebook.com/micmedia/posts/1306645779358209' />));
   const expected = renderString(tree(
-    <iframe id='facebook-micmedia/posts/1306645779358209' type='facebook' frameBorder='0' width='100%' src='javascript:false'></iframe>));
+    <iframe id='facebook-micmediaposts1306645779358209' type='facebook' frameBorder='0' width='100%' src='javascript:false'></iframe>));
   t.equal(actual, expected);
   t.end();
 });
@@ -214,7 +214,7 @@ test('loadEmbed()', t => {
 test('TumblrEmbed - body', t => {
   const actual = renderString(tree(<TumblrEmbed id='153824541111' url='https://embed.tumblr.com/embed/post/xlBeooAJ19N2jNN7Y_z92A/153824541111' />));
   const expected = renderString(tree(
-    <iframe id='tumblr-embed/post/xlBeooAJ19N2jNN7Y_z92A/153824541111' type='tumblr' frameBorder='0' width='100%' src='javascript:false'></iframe>));
+    <iframe id='tumblr-embedpostxlBeooAJ19N2jNN7Y_z92A153824541111' type='tumblr' frameBorder='0' width='100%' src='javascript:false'></iframe>));
   t.equal(actual, expected);
   t.end();
 });

--- a/test/embeds-test.js
+++ b/test/embeds-test.js
@@ -22,9 +22,9 @@ const fixtures = {
 const test = process.browser ? _test : function () {};
 
 test('FacebookEmbed - body', t => {
-  const actual = renderString(tree(<FacebookEmbed embedAs='post' id='123' />));
+  const actual = renderString(tree(<FacebookEmbed embedAs='post' url='https://www.facebook.com/micmedia/posts/1306645779358209' />));
   const expected = renderString(tree(
-    <iframe id='facebook-123' type='facebook' frameBorder='0' width='100%' src='javascript:false'></iframe>));
+    <iframe id='facebook-micmedia/posts/1306645779358209' type='facebook' frameBorder='0' width='100%' src='javascript:false'></iframe>));
   t.equal(actual, expected);
   t.end();
 });
@@ -214,7 +214,7 @@ test('loadEmbed()', t => {
 test('TumblrEmbed - body', t => {
   const actual = renderString(tree(<TumblrEmbed id='153824541111' url='https://embed.tumblr.com/embed/post/xlBeooAJ19N2jNN7Y_z92A/153824541111' />));
   const expected = renderString(tree(
-    <iframe id='tumblr-153824541111' type='tumblr' frameBorder='0' width='100%' src='javascript:false'></iframe>));
+    <iframe id='tumblr-embed/post/xlBeooAJ19N2jNN7Y_z92A/153824541111' type='tumblr' frameBorder='0' width='100%' src='javascript:false'></iframe>));
   t.equal(actual, expected);
   t.end();
 });

--- a/test/patch-dom-test.js
+++ b/test/patch-dom-test.js
@@ -189,6 +189,50 @@ test('patchDom() insert paragraph between embeds', t => {
   t.end();
 });
 
+test('patchDom() insert paragraph between embeds', t => {
+  const oldItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070'
+  }, {
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'beep boop'
+    }]
+  }, {
+    type: 'embed',
+    embedType: 'instagram',
+    id: 'tsxp1hhQTG',
+    url: 'https://instagram.com/p/tsxp1hhQTG'
+  }];
+  const newItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070'
+  }, {
+    type: 'embed',
+    embedType: 'instagram',
+    id: 'tsxp1hhQTG',
+    url: 'https://instagram.com/p/tsxp1hhQTG'
+  }];
+  const oldArticleElm = renderArticle(oldItems);
+  const newArticleElm = renderArticle(newItems);
+  patchDom({oldArticleElm, newArticleElm});
+
+  t.is(pretty(oldArticleElm.innerHTML), pretty(
+    `<figure>
+      <iframe id="facebook-davidbjorklundposts10153809692501070" type="facebook"
+      frameborder="0" width="100%" src="javascript:false"></iframe>
+    </figure>
+    <figure>
+      <iframe id="instagram-tsxp1hhQTG" type="instagram" frameborder="0"
+        width="100%" src="javascript:false"></iframe>
+    </figure>`
+  ));
+  t.end();
+});
+
 test('patchDom() move paragraph', t => {
   const oldItems = [{
     type: 'paragraph',

--- a/test/patch-dom-test.js
+++ b/test/patch-dom-test.js
@@ -181,3 +181,85 @@ test('patchDom() insert paragraph between embeds', t => {
   ].join(''));
   t.end();
 });
+
+test('patchDom() move paragraph', t => {
+  const oldItems = [{
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'beep'
+    }]
+  }, {
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'boop'
+    }]
+  }, {
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'baap'
+    }]
+  }];
+  const newItems = [{
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'boop'
+    }]
+  }, {
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'beep'
+    }]
+  }, {
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'baap'
+    }]
+  }];
+  const oldArticleElm = renderArticle(oldItems);
+  const newArticleElm = renderArticle(newItems);
+  patchDom({oldArticleElm, newArticleElm});
+
+  t.is(oldArticleElm.innerHTML, '<p>boop</p><p>beep</p><p>baap</p>');
+  t.end();
+});
+
+test('patchDom() move embed', t => {
+  const oldItems = [{
+    type: 'embed',
+    embedType: 'instagram',
+    id: 'tsxp1hhQTG',
+    url: 'https://instagram.com/p/tsxp1hhQTG'
+  }, {
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070'
+  }];
+  const newItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070'
+  }, {
+    type: 'embed',
+    embedType: 'instagram',
+    id: 'tsxp1hhQTG',
+    url: 'https://instagram.com/p/tsxp1hhQTG'
+  }];
+  const oldArticleElm = renderArticle(oldItems);
+  const newArticleElm = renderArticle(newItems);
+  patchDom({oldArticleElm, newArticleElm});
+
+  t.is(oldArticleElm.innerHTML, ['<figure>',
+    '<iframe id="facebook-davidbjorklundposts10153809692501070" type="facebook" ',
+    'frameborder="0" width="100%" src="javascript:false"></iframe></figure>',
+    '<figure><iframe id="instagram-tsxp1hhQTG" type="instagram" frameborder="0" ',
+    'width="100%" src="javascript:false"></iframe>',
+    '</figure>'
+  ].join(''));
+  t.end();
+});

--- a/test/patch-dom-test.js
+++ b/test/patch-dom-test.js
@@ -273,3 +273,51 @@ test('patchDom() move embed', t => {
   ));
   t.end();
 });
+
+test('patchDom() formatting and move with identical paragraphs', t => {
+  const oldItems = [{
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'beep'
+    }]
+  }, {
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'boop'
+    }]
+  }, {
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'beep'
+    }]
+  }];
+  const newItems = [{
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'beep',
+      bold: true
+    }]
+  }, {
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'beep'
+    }]
+  }, {
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'boop'
+    }]
+  }];
+  const oldArticleElm = renderArticle(oldItems);
+  const newArticleElm = renderArticle(newItems);
+  patchDom({oldArticleElm, newArticleElm});
+
+  t.is(pretty(oldArticleElm.innerHTML), pretty('<p><b>beep</b></p><p>beep</p><p>boop</p>'));
+  t.end();
+});

--- a/test/patch-dom-test.js
+++ b/test/patch-dom-test.js
@@ -236,7 +236,7 @@ test('patchDom() move paragraph', t => {
   t.end();
 });
 
-test('patchDom() move embed', t => {
+test('patchDom() move custom iframe embed', t => {
   const oldItems = [{
     type: 'embed',
     embedType: 'instagram',
@@ -269,6 +269,45 @@ test('patchDom() move embed', t => {
     <figure>
       <iframe id="instagram-tsxp1hhQTG" type="instagram" frameborder="0"
       width="100%" src="javascript:false"></iframe>
+    </figure>`
+  ));
+  t.end();
+});
+
+test('patchDom() move embed', t => {
+  const oldItems = [{
+    type: 'embed',
+    embedType: 'youtube',
+    url: 'https://www.youtube.com/embed/I7IdS-PbEgI',
+    youtubeId: 'I7IdS-PbEgI'
+  }, {
+    type: 'embed',
+    embedType: 'custom',
+    src: 'https://giphy.com/embed/3oxRmeLK7bjcq0CCCA',
+    secure: true
+  }];
+  const newItems = [{
+    type: 'embed',
+    embedType: 'custom',
+    src: 'https://giphy.com/embed/3oxRmeLK7bjcq0CCCA',
+    secure: true
+  }, {
+    type: 'embed',
+    embedType: 'youtube',
+    url: 'https://www.youtube.com/embed/I7IdS-PbEgI',
+    youtubeId: 'I7IdS-PbEgI'
+  }];
+  const oldArticleElm = renderArticle(oldItems);
+  const newArticleElm = renderArticle(newItems);
+  patchDom({oldArticleElm, newArticleElm});
+
+  t.is(pretty(oldArticleElm.innerHTML), pretty(
+    `<figure>
+      <iframe src="https://giphy.com/embed/3oxRmeLK7bjcq0CCCA" frameborder="0"></iframe>
+    </figure>
+    <figure>
+      <iframe src="https://www.youtube.com/embed/I7IdS-PbEgI" width="640" height="360"
+        frameborder="0" allowfullscreen="true"></iframe>
     </figure>`
   ));
   t.end();

--- a/test/patch-dom-test.js
+++ b/test/patch-dom-test.js
@@ -333,10 +333,10 @@ test('patchDom() add embed attribution', t => {
     embedType: 'facebook',
     url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070',
     attribution: [
-     {type: 'text', content: 'Source: '},
-     {type: 'text', content: 'author/source', href: 'http://example.com'}
-   ],
-   caption: [{type: 'text', content: 'Embed caption'}]
+      {type: 'text', content: 'Source: '},
+      {type: 'text', content: 'author/source', href: 'http://example.com'}
+    ],
+    caption: [{type: 'text', content: 'Embed caption'}]
   }];
   const oldArticleElm = renderArticle(oldItems);
   const newArticleElm = renderArticle(newItems);
@@ -360,10 +360,10 @@ test('patchDom() remove embed attribution', t => {
     embedType: 'facebook',
     url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070',
     attribution: [
-     {type: 'text', content: 'Source: '},
-     {type: 'text', content: 'author/source', href: 'http://example.com'}
-   ],
-   caption: [{type: 'text', content: 'Embed caption'}]
+      {type: 'text', content: 'Source: '},
+      {type: 'text', content: 'author/source', href: 'http://example.com'}
+    ],
+    caption: [{type: 'text', content: 'Embed caption'}]
   }];
   const newItems = [{
     type: 'embed',
@@ -389,20 +389,20 @@ test('patchDom() edit embed attribution', t => {
     embedType: 'facebook',
     url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070',
     attribution: [
-     {type: 'text', content: 'Source: '},
-     {type: 'text', content: 'author/source', href: 'http://example.com'}
-   ],
-   caption: [{type: 'text', content: 'Embed caption'}]
+      {type: 'text', content: 'Source: '},
+      {type: 'text', content: 'author/source', href: 'http://example.com'}
+    ],
+    caption: [{type: 'text', content: 'Embed caption'}]
   }];
   const newItems = [{
     type: 'embed',
     embedType: 'facebook',
     url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070',
     attribution: [
-     {type: 'text', content: 'Source: '},
-     {type: 'text', content: 'author/source', href: 'http://example-2.com'}
-   ],
-   caption: [{type: 'text', content: 'Updated embed caption'}]
+      {type: 'text', content: 'Source: '},
+      {type: 'text', content: 'author/source', href: 'http://example-2.com'}
+    ],
+    caption: [{type: 'text', content: 'Updated embed caption'}]
   }];
   const oldArticleElm = renderArticle(oldItems);
   const newArticleElm = renderArticle(newItems);

--- a/test/patch-dom-test.js
+++ b/test/patch-dom-test.js
@@ -1,4 +1,5 @@
 import _test from 'tape-catch';
+import pretty from 'pretty';
 import element from 'magic-virtual-element';
 import { render, tree } from 'deku';
 import setupArticle from 'article-json-html-render';
@@ -36,7 +37,7 @@ test('patchDom() edit paragraph', t => {
   const newArticleElm = renderArticle(newItems);
   patchDom({oldArticleElm, newArticleElm});
 
-  t.is(oldArticleElm.innerHTML, '<p>beep boop</p>');
+  t.is(pretty(oldArticleElm.innerHTML), pretty('<p>beep boop</p>'));
   t.end();
 });
 
@@ -65,7 +66,7 @@ test('patchDom() remove paragraph', t => {
   const newArticleElm = renderArticle(newItems);
   patchDom({oldArticleElm, newArticleElm});
 
-  t.is(oldArticleElm.innerHTML, '<p>boop</p>');
+  t.is(pretty(oldArticleElm.innerHTML), pretty('<p>boop</p>'));
   t.end();
 });
 
@@ -106,7 +107,7 @@ test('patchDom() insert paragraph', t => {
   const newArticleElm = renderArticle(newItems);
   patchDom({oldArticleElm, newArticleElm});
 
-  t.is(oldArticleElm.innerHTML, '<p>beep</p><p>foo</p><p>boop</p>');
+  t.is(pretty(oldArticleElm.innerHTML), pretty('<p>beep</p><p>foo</p><p>boop</p>'));
   t.end();
 });
 
@@ -130,13 +131,16 @@ test('patchDom() add embed', t => {
   const newArticleElm = renderArticle(newItems);
   patchDom({oldArticleElm, newArticleElm});
 
-  t.is(oldArticleElm.innerHTML, ['<figure>',
-    '<iframe id="facebook-davidbjorklundposts10153809692501070" type="facebook" ',
-    'frameborder="0" width="100%" src="javascript:false"></iframe></figure>',
-    '<figure><iframe id="instagram-tsxp1hhQTG" type="instagram" frameborder="0" ',
-    'width="100%" src="javascript:false"></iframe>',
-    '</figure>'
-  ].join(''));
+  t.is(pretty(oldArticleElm.innerHTML), pretty(
+    `<figure>
+      <iframe id="facebook-davidbjorklundposts10153809692501070" type="facebook"
+        frameborder="0" width="100%" src="javascript:false"></iframe>
+    </figure>
+    <figure>
+      <iframe id="instagram-tsxp1hhQTG" type="instagram" frameborder="0"
+      width="100%" src="javascript:false"></iframe>
+    </figure>`
+  ));
   t.end();
 });
 
@@ -171,14 +175,17 @@ test('patchDom() insert paragraph between embeds', t => {
   const newArticleElm = renderArticle(newItems);
   patchDom({oldArticleElm, newArticleElm});
 
-  t.is(oldArticleElm.innerHTML, ['<figure>',
-    '<iframe id="facebook-davidbjorklundposts10153809692501070" type="facebook" ',
-    'frameborder="0" width="100%" src="javascript:false"></iframe></figure>',
-    '<p>beep boop</p>',
-    '<figure><iframe id="instagram-tsxp1hhQTG" type="instagram" frameborder="0" ',
-    'width="100%" src="javascript:false"></iframe>',
-    '</figure>'
-  ].join(''));
+  t.is(pretty(oldArticleElm.innerHTML), pretty(
+    `<figure>
+      <iframe id="facebook-davidbjorklundposts10153809692501070" type="facebook"
+      frameborder="0" width="100%" src="javascript:false"></iframe>
+    </figure>
+    <p>beep boop</p>
+    <figure>
+      <iframe id="instagram-tsxp1hhQTG" type="instagram" frameborder="0"
+        width="100%" src="javascript:false"></iframe>
+    </figure>`
+  ));
   t.end();
 });
 
@@ -225,7 +232,7 @@ test('patchDom() move paragraph', t => {
   const newArticleElm = renderArticle(newItems);
   patchDom({oldArticleElm, newArticleElm});
 
-  t.is(oldArticleElm.innerHTML, '<p>boop</p><p>beep</p><p>baap</p>');
+  t.is(pretty(oldArticleElm.innerHTML), pretty('<p>boop</p><p>beep</p><p>baap</p>'));
   t.end();
 });
 
@@ -254,12 +261,15 @@ test('patchDom() move embed', t => {
   const newArticleElm = renderArticle(newItems);
   patchDom({oldArticleElm, newArticleElm});
 
-  t.is(oldArticleElm.innerHTML, ['<figure>',
-    '<iframe id="facebook-davidbjorklundposts10153809692501070" type="facebook" ',
-    'frameborder="0" width="100%" src="javascript:false"></iframe></figure>',
-    '<figure><iframe id="instagram-tsxp1hhQTG" type="instagram" frameborder="0" ',
-    'width="100%" src="javascript:false"></iframe>',
-    '</figure>'
-  ].join(''));
+  t.is(pretty(oldArticleElm.innerHTML), pretty(
+    `<figure>
+      <iframe id="facebook-davidbjorklundposts10153809692501070" type="facebook"
+      frameborder="0" width="100%" src="javascript:false"></iframe>
+    </figure>
+    <figure>
+      <iframe id="instagram-tsxp1hhQTG" type="instagram" frameborder="0"
+      width="100%" src="javascript:false"></iframe>
+    </figure>`
+  ));
   t.end();
 });

--- a/test/patch-dom-test.js
+++ b/test/patch-dom-test.js
@@ -419,3 +419,35 @@ test('patchDom() edit embed attribution', t => {
   ));
   t.end();
 });
+
+test('patchDom() update figureProps', t => {
+  const oldItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070',
+    figureProps: {
+      class: 'some-class',
+      'data-foo': 'bar'
+    }
+  }];
+  const newItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070',
+    figureProps: {
+      class: 'some-other-class',
+      'data-beep': 'boop'
+    }
+  }];
+  const oldArticleElm = renderArticle(oldItems);
+  const newArticleElm = renderArticle(newItems);
+  patchDom({oldArticleElm, newArticleElm});
+
+  t.is(pretty(oldArticleElm.innerHTML), pretty(
+    `<figure class="some-other-class" data-beep="boop">
+      <iframe id="facebook-davidbjorklundposts10153809692501070" type="facebook"
+      frameborder="0" width="100%" src="javascript:false"></iframe>
+    </figure>`
+  ));
+  t.end();
+});

--- a/test/patch-dom-test.js
+++ b/test/patch-dom-test.js
@@ -321,3 +321,101 @@ test('patchDom() formatting and move with identical paragraphs', t => {
   t.is(pretty(oldArticleElm.innerHTML), pretty('<p><b>beep</b></p><p>beep</p><p>boop</p>'));
   t.end();
 });
+
+test('patchDom() add embed attribution', t => {
+  const oldItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070'
+  }];
+  const newItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070',
+    attribution: [
+     {type: 'text', content: 'Source: '},
+     {type: 'text', content: 'author/source', href: 'http://example.com'}
+   ],
+   caption: [{type: 'text', content: 'Embed caption'}]
+  }];
+  const oldArticleElm = renderArticle(oldItems);
+  const newArticleElm = renderArticle(newItems);
+  patchDom({oldArticleElm, newArticleElm});
+
+  t.is(pretty(oldArticleElm.innerHTML), pretty(
+    `<figure>
+      <iframe id="facebook-davidbjorklundposts10153809692501070" type="facebook"
+      frameborder="0" width="100%" src="javascript:false"></iframe>
+      <figcaption>Embed caption
+        <cite>Source: <a href="http://example.com">author/source</a></cite>
+      </figcaption>
+    </figure>`
+  ));
+  t.end();
+});
+
+test('patchDom() remove embed attribution', t => {
+  const oldItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070',
+    attribution: [
+     {type: 'text', content: 'Source: '},
+     {type: 'text', content: 'author/source', href: 'http://example.com'}
+   ],
+   caption: [{type: 'text', content: 'Embed caption'}]
+  }];
+  const newItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070'
+  }];
+  const oldArticleElm = renderArticle(oldItems);
+  const newArticleElm = renderArticle(newItems);
+  patchDom({oldArticleElm, newArticleElm});
+
+  t.is(pretty(oldArticleElm.innerHTML), pretty(
+    `<figure>
+      <iframe id="facebook-davidbjorklundposts10153809692501070" type="facebook"
+      frameborder="0" width="100%" src="javascript:false"></iframe>
+    </figure>`
+  ));
+  t.end();
+});
+
+test('patchDom() edit embed attribution', t => {
+  const oldItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070',
+    attribution: [
+     {type: 'text', content: 'Source: '},
+     {type: 'text', content: 'author/source', href: 'http://example.com'}
+   ],
+   caption: [{type: 'text', content: 'Embed caption'}]
+  }];
+  const newItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070',
+    attribution: [
+     {type: 'text', content: 'Source: '},
+     {type: 'text', content: 'author/source', href: 'http://example-2.com'}
+   ],
+   caption: [{type: 'text', content: 'Updated embed caption'}]
+  }];
+  const oldArticleElm = renderArticle(oldItems);
+  const newArticleElm = renderArticle(newItems);
+  patchDom({oldArticleElm, newArticleElm});
+
+  t.is(pretty(oldArticleElm.innerHTML), pretty(
+    `<figure>
+      <iframe id="facebook-davidbjorklundposts10153809692501070" type="facebook"
+      frameborder="0" width="100%" src="javascript:false"></iframe>
+      <figcaption>Updated embed caption
+        <cite>Source: <a href="http://example-2.com">author/source</a></cite>
+      </figcaption>
+    </figure>`
+  ));
+  t.end();
+});

--- a/test/patch-dom-test.js
+++ b/test/patch-dom-test.js
@@ -1,0 +1,183 @@
+import _test from 'tape-catch';
+import element from 'magic-virtual-element';
+import { render, tree } from 'deku';
+import setupArticle from 'article-json-html-render';
+import patchDom from '../lib/patch-dom';
+import embeds from '../lib/embeds';
+
+const test = process.browser ? _test : function () {};
+const Article = setupArticle({
+  embeds,
+  renderEmptyTextNodes: true
+});
+
+const renderArticle = (items) => {
+  const container = document.createElement('div');
+  render(tree(<Article items={items} />), container);
+  return container.querySelector('article');
+};
+
+test('patchDom() edit paragraph', t => {
+  const oldItems = [{
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'beep'
+    }]
+  }];
+  const newItems = [{
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'beep boop'
+    }]
+  }];
+  const oldArticleElm = renderArticle(oldItems);
+  const newArticleElm = renderArticle(newItems);
+  patchDom({oldArticleElm, newArticleElm});
+
+  t.is(oldArticleElm.innerHTML, '<p>beep boop</p>');
+  t.end();
+});
+
+test('patchDom() remove paragraph', t => {
+  const oldItems = [{
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'beep'
+    }]
+  }, {
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'boop'
+    }]
+  }];
+  const newItems = [{
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'boop'
+    }]
+  }];
+  const oldArticleElm = renderArticle(oldItems);
+  const newArticleElm = renderArticle(newItems);
+  patchDom({oldArticleElm, newArticleElm});
+
+  t.is(oldArticleElm.innerHTML, '<p>boop</p>');
+  t.end();
+});
+
+test('patchDom() insert paragraph', t => {
+  const oldItems = [{
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'beep'
+    }]
+  }, {
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'boop'
+    }]
+  }];
+  const newItems = [{
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'beep'
+    }]
+  }, {
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'foo'
+    }]
+  }, {
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'boop'
+    }]
+  }];
+  const oldArticleElm = renderArticle(oldItems);
+  const newArticleElm = renderArticle(newItems);
+  patchDom({oldArticleElm, newArticleElm});
+
+  t.is(oldArticleElm.innerHTML, '<p>beep</p><p>foo</p><p>boop</p>');
+  t.end();
+});
+
+test('patchDom() add embed', t => {
+  const oldItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070'
+  }];
+  const newItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070'
+  }, {
+    type: 'embed',
+    embedType: 'instagram',
+    id: 'tsxp1hhQTG',
+    url: 'https://instagram.com/p/tsxp1hhQTG'
+  }];
+  const oldArticleElm = renderArticle(oldItems);
+  const newArticleElm = renderArticle(newItems);
+  patchDom({oldArticleElm, newArticleElm});
+
+  t.is(oldArticleElm.innerHTML, ['<figure>',
+    '<iframe id="facebook-davidbjorklundposts10153809692501070" type="facebook" ',
+    'frameborder="0" width="100%" src="javascript:false"></iframe></figure>',
+    '<figure><iframe id="instagram-tsxp1hhQTG" type="instagram" frameborder="0" ',
+    'width="100%" src="javascript:false"></iframe>',
+    '</figure>'
+  ].join(''));
+  t.end();
+});
+
+test('patchDom() insert paragraph between embeds', t => {
+  const oldItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070'
+  }, {
+    type: 'embed',
+    embedType: 'instagram',
+    id: 'tsxp1hhQTG',
+    url: 'https://instagram.com/p/tsxp1hhQTG'
+  }];
+  const newItems = [{
+    type: 'embed',
+    embedType: 'facebook',
+    url: 'https://www.facebook.com/david.bjorklund/posts/10153809692501070'
+  }, {
+    type: 'paragraph',
+    children: [{
+      type: 'text',
+      content: 'beep boop'
+    }]
+  }, {
+    type: 'embed',
+    embedType: 'instagram',
+    id: 'tsxp1hhQTG',
+    url: 'https://instagram.com/p/tsxp1hhQTG'
+  }];
+  const oldArticleElm = renderArticle(oldItems);
+  const newArticleElm = renderArticle(newItems);
+  patchDom({oldArticleElm, newArticleElm});
+
+  t.is(oldArticleElm.innerHTML, ['<figure>',
+    '<iframe id="facebook-davidbjorklundposts10153809692501070" type="facebook" ',
+    'frameborder="0" width="100%" src="javascript:false"></iframe></figure>',
+    '<p>beep boop</p>',
+    '<figure><iframe id="instagram-tsxp1hhQTG" type="instagram" frameborder="0" ',
+    'width="100%" src="javascript:false"></iframe>',
+    '</figure>'
+  ].join(''));
+  t.end();
+});


### PR DESCRIPTION
Type: Patch
Review: @danmakenoise @iefserge 

Had some issues where embeds kept reloading more often than necessary, tried fixing this inside morphdom but ended up switching to `dift` for patching the dom. This gives us more control over how we want to do our updates so it's easier to do performance tweaks for things like the embed reloading issue. 