### PR TITLE
Add contenteditable as prop, defaulting to 'true'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,7 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
 
   return {
     name: 'Wrapper',
-    render: ({props: {onUpdate, getCustomKeyDown, selections = true}}) => {
+    render: ({props: {onUpdate, getCustomKeyDown, selections = true, contenteditable = 'true'}}) => {
       const eventhandler = ({delegateTarget: articleContainer}) => {
         const activeItem = getIndexAndRectOfActiveEditorBlock(articleContainer);
         const selectionBoundingClientRect = getSelectionRect(articleContainer);
@@ -73,11 +73,13 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
       };
 
       const events = objectAssign({onBlur}, setupEvents(eventhandler, getCustomKeyDown));
-      const articleProps = objectAssign({contenteditable: 'true'}, events);
-      return <Article items={[]} contenteditable='true' articleProps={articleProps} />;
+      const articleProps = objectAssign({contenteditable}, events);
+      return <Article items={[]} articleProps={articleProps} />;
     },
     shouldUpdate: ({props}, nextProps) => {
-      return props.items !== nextProps.items || props.selections !== nextProps.selections;
+      return props.items !== nextProps.items ||
+        props.selections !== nextProps.selections ||
+        props.contenteditable !== nextProps.contenteditable;
     },
     afterRender: ({props: {items, selections = true}}, oldArticleElm) => {
       const app = tree(<Article items={map(items, formatItems)} />);

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -19,6 +19,14 @@ test('<ArticleJsonToContenteditable />', t => {
   t.end();
 });
 
+test('<ArticleJsonToContenteditable contenteditable=false />', t => {
+  const expected = renderString(tree(<article contenteditable='false'></article>));
+  const actual = renderString(tree(<ArticleJsonToContenteditable contenteditable='false' items={[]} />));
+
+  t.equal(actual, expected);
+  t.end();
+});
+
 function keydown (opts) {
   return createEvent('keydown', opts);
 }


### PR DESCRIPTION
Type: Minor
Review: @danmakenoise @iefserge 

I need to temporarily disable editing of article, while parsing and loading data for embeds and uploading images, so adding a property allowing to disable contenteditable. 