### PR TITLE
Url parse fixes

### DIFF
--- a/lib/parse-url.js
+++ b/lib/parse-url.js
@@ -13,7 +13,7 @@ export default (elm) => {
   }
 
   const content = elm.textContent || '';
-  if (!isUrl(content)) {
+  if (!content.match(/^https?:\/\//) || !isUrl(content)) {
     return null;
   }
 

--- a/lib/parse-url.js
+++ b/lib/parse-url.js
@@ -8,7 +8,7 @@ const validEmbedTypes = Object.keys(embeds);
 const isValidEmbedType = ({type}) => validEmbedTypes.indexOf(type) !== -1;
 
 export default (elm) => {
-  if (!elm) {
+  if (!elm || (elm.tagName && elm.tagName.toLowerCase() === 'article')) {
     return null;
   }
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -596,9 +596,65 @@ if (process.browser) {
     }];
     const app = tree(<ArticleJsonToContenteditable items={items} onUpdate={onUpdate}/>);
     const container = renderAppInContainer(app);
-    const firstParagraph = container.querySelector('article p');
     const newParagraph = document.createElement('p');
     newParagraph.innerHTML = 'https://www.facebook.com/MicMedia/videos/1318391108183676';
+    container.querySelector('article').appendChild(newParagraph);
+
+    let onUpdateCalled = false;
+
+    function onUpdate ({items: actual}) {
+      onUpdateCalled = true;
+      t.deepEqual(actual, expected);
+    }
+
+    container.querySelector('article').dispatchEvent(mouseup());
+    t.ok(onUpdateCalled, 'onUpdate was called');
+    t.end();
+  });
+
+  test('<ArticleJsonToContenteditable /> add url to parse to embed', t => {
+    const items = [{
+      type: 'paragraph',
+      children: [{
+        bold: false,
+        content: 'Text',
+        href: null,
+        italic: false,
+        mark: false,
+        markClass: null,
+        strikethrough: false,
+        type: 'text'
+      }]
+    }];
+    const expected = [{
+      type: 'paragraph',
+      children: [{
+        bold: false,
+        content: 'Text',
+        href: null,
+        italic: false,
+        mark: false,
+        markClass: null,
+        strikethrough: false,
+        type: 'text'
+      }]
+    }, {
+      type: 'paragraph',
+      children: [{
+        bold: false,
+        content: 'notavalidprotocolhttps://www.facebook.com/MicMedia/videos/1318391108183676',
+        href: null,
+        italic: false,
+        mark: false,
+        markClass: null,
+        strikethrough: false,
+        type: 'text'
+      }]
+    }];
+    const app = tree(<ArticleJsonToContenteditable items={items} onUpdate={onUpdate}/>);
+    const container = renderAppInContainer(app);
+    const newParagraph = document.createElement('p');
+    newParagraph.innerHTML = 'notavalidprotocolhttps://www.facebook.com/MicMedia/videos/1318391108183676';
     container.querySelector('article').appendChild(newParagraph);
 
     let onUpdateCalled = false;

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -559,4 +559,57 @@ if (process.browser) {
     t.is(actual, expected);
     t.end();
   });
+
+  test('<ArticleJsonToContenteditable /> add url to parse to embed', t => {
+    const items = [{
+      type: 'paragraph',
+      children: [{
+        bold: false,
+        content: 'Text',
+        href: null,
+        italic: false,
+        mark: false,
+        markClass: null,
+        strikethrough: false,
+        type: 'text'
+      }]
+    }];
+    const expected = [{
+      type: 'paragraph',
+      children: [{
+        bold: false,
+        content: 'Text',
+        href: null,
+        italic: false,
+        mark: false,
+        markClass: null,
+        strikethrough: false,
+        type: 'text'
+      }]
+    }, {
+      type: 'embed',
+      embedType: 'facebook',
+      url: 'https://www.facebook.com/MicMedia/videos/1318391108183676',
+      id: '1318391108183676',
+      embedAs: 'video',
+      user: 'MicMedia'
+    }];
+    const app = tree(<ArticleJsonToContenteditable items={items} onUpdate={onUpdate}/>);
+    const container = renderAppInContainer(app);
+    const firstParagraph = container.querySelector('article p');
+    const newParagraph = document.createElement('p');
+    newParagraph.innerHTML = 'https://www.facebook.com/MicMedia/videos/1318391108183676';
+    container.querySelector('article').appendChild(newParagraph);
+
+    let onUpdateCalled = false;
+
+    function onUpdate ({items: actual}) {
+      onUpdateCalled = true;
+      t.deepEqual(actual, expected);
+    }
+
+    container.querySelector('article').dispatchEvent(mouseup());
+    t.ok(onUpdateCalled, 'onUpdate was called');
+    t.end();
+  });
 }


### PR DESCRIPTION
Type: Patch
Review: @danmakenoise @iefserge @kesla 

Pasting a url would sometimes remove everything else in the article body, this fixes that bug. Also added another url check, since since the is-url allows any protocol but we are only interested in http or https urls. 