### PR TITLE
Performance fixes

### DIFF
--- a/lib/embeds/facebook.js
+++ b/lib/embeds/facebook.js
@@ -5,8 +5,8 @@ import renderEmbedIframe from './render-embed-iframe';
 
 export default {
   name: 'FacebookEmbed',
-  render: function ({props: {url}}) {
-    return renderEmbedIframe({url, type: 'facebook'});
+  render: function ({props: {url, height}}) {
+    return renderEmbedIframe({url, height, type: 'facebook'});
   },
   afterMount: function ({props}, iframe) {
     iframe.__props__ = props;

--- a/lib/embeds/instagram.js
+++ b/lib/embeds/instagram.js
@@ -5,8 +5,8 @@ import renderEmbedIframe from './render-embed-iframe';
 
 export default {
   name: 'InstagramEmbed',
-  render: ({props: {id}}) => {
-    return renderEmbedIframe({id, type: 'instagram'});
+  render: ({props: {id, height}}) => {
+    return renderEmbedIframe({id, height, type: 'instagram'});
   },
   afterMount: ({props}, iframe) => {
     iframe.__props__ = props;

--- a/lib/embeds/instagram.js
+++ b/lib/embeds/instagram.js
@@ -18,7 +18,16 @@ export default {
       : '';
 
     const script = `<script src="${protocol}//platform.instagram.com/en_US/embeds.js"></script>
-      <script>resize()</script>`;
+      <script>
+        const interval = setInterval(function () {
+          const iframe = document.querySelector('iframe.instagram-media-rendered');
+          if (iframe && iframe.height) {
+            resize();
+            clearInterval(interval);
+          }
+        }, 100);
+        resize();
+      </script>`;
 
     loadEmbed({ content: content + script, iframe, onLoaded, onResize });
   }

--- a/lib/embeds/instagram.js
+++ b/lib/embeds/instagram.js
@@ -26,7 +26,6 @@ export default {
             clearInterval(interval);
           }
         }, 100);
-        resize();
       </script>`;
 
     loadEmbed({ content: content + script, iframe, onLoaded, onResize });

--- a/lib/embeds/render-embed-iframe.js
+++ b/lib/embeds/render-embed-iframe.js
@@ -1,6 +1,13 @@
 import element from 'magic-virtual-element';
 
-export default ({id, url = '', type}) => {
+export default ({id, url = '', height, type}) => {
   const embedId = id || url.replace(/https:\/\/[^\/]*\//, '').replace(/\W+/g, '');
-  return (<iframe id={`${type}-${embedId}`} type={`${type}`} frameBorder='0' width='100%' src='javascript:false'></iframe>);
+  return (<iframe
+      id={`${type}-${embedId}`}
+      type={`${type}`}
+      frameBorder='0'
+      width='100%'
+      src='javascript:false'
+      height={height}>
+    </iframe>);
 };

--- a/lib/embeds/tumblr.js
+++ b/lib/embeds/tumblr.js
@@ -5,8 +5,8 @@ import renderEmbedIframe from './render-embed-iframe';
 
 export default {
   name: 'TumblrEmbed',
-  render: ({props: {url}}) => {
-    return renderEmbedIframe({url, type: 'tumblr'});
+  render: ({props: {url, height}}) => {
+    return renderEmbedIframe({url, height, type: 'tumblr'});
   },
   afterMount: ({props}, iframe) => {
     iframe.__props__ = props;

--- a/lib/embeds/twitter.js
+++ b/lib/embeds/twitter.js
@@ -5,8 +5,8 @@ import renderEmbedIframe from './render-embed-iframe';
 
 export default {
   name: 'TwitterEmbed',
-  render: ({props: {id}}) => {
-    return renderEmbedIframe({id, type: 'twitter'});
+  render: ({props: {id, height}}) => {
+    return renderEmbedIframe({id, height, type: 'twitter'});
   },
   afterMount: ({props}, iframe) => {
     iframe.__props__ = props;

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,9 @@ function parseEmbed (type) {
   };
 }
 
+let currentElement = {};
+let nextElement = {};
+
 const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) => {
   const htmlToArticleJson = setupHtmlToArticleJson({
     customEmbedTypes: [{
@@ -54,6 +57,13 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
     customCaption
   });
 
+  function renderArticleJson ({ items }) {
+    const app = tree(<Article items={map(items, formatItems)} />);
+    const tmpElm = document.createElement('div');
+    render(app, tmpElm);
+    return tmpElm.querySelector('article');
+  }
+
   return {
     name: 'Wrapper',
     render: ({props: {onUpdate, getCustomKeyDown, selections = true, contenteditable = 'true'}}) => {
@@ -76,17 +86,20 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
       const articleProps = objectAssign({contenteditable}, events);
       return <Article items={[]} articleProps={articleProps} />;
     },
-    shouldUpdate: ({props}, nextProps) => {
-      return props.items !== nextProps.items ||
+    shouldUpdate: ({props, id}, nextProps) => {
+      const current = currentElement[id];
+      const next = renderArticleJson({ items: nextProps.items });
+      nextElement[id] = next;
+      const itemsHasUpdated = props.items !== nextProps.items;
+      const htmlHasUpdated = itemsHasUpdated && next.innerHTML !== current.innerHTML;
+
+      return htmlHasUpdated ||
         props.selections !== nextProps.selections ||
         props.contenteditable !== nextProps.contenteditable;
     },
-    afterRender: ({props: {items, selections = true}}, oldArticleElm) => {
-      const app = tree(<Article items={map(items, formatItems)} />);
-
-      const tmpElm = document.createElement('div');
-      render(app, tmpElm);
-      const newArticleElm = tmpElm.querySelector('article');
+    afterRender: ({props: {items, selections = true}, id}, oldArticleElm) => {
+      currentElement[id] = oldArticleElm;
+      const newArticleElm = nextElement[id] || renderArticleJson({ items });
 
       assert(oldArticleElm, 'oldArticleElm must exists');
       assert(newArticleElm, 'newArticleElm must exists');

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ function parseEmbed (type) {
       return null;
     }
 
-    return elm.__props__;
+    return objectAssign({ width: elm.width, height: elm.height }, elm.__props__);
   };
 }
 


### PR DESCRIPTION
Type: Patch

Potentially solving an issue where the editor keeps freezing and overall being slow, especially for longer articles with multiple embeds. 

With this PR I made sure we don't do more renders than we need to. Most of the updates that currently initiates a new render will be because of direct user input that don't require any cleaning up or parsing, and for those updates we can avoid actually going through the whole render because the html has already been updated correctly by the user. Doing this by moving the rendering of articleJson to shouldUpdate and checking if the actual html in the dom already matches what the update would render.

Looking into if there's some more tests I should add for this, but overall we should be covered here by the existing tests since the functionality does stay the same, but should perform a bit better. 