### PR TITLE
shouldUpdate = true when items has changed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,12 +88,14 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
     },
     shouldUpdate: ({props, id}, nextProps) => {
       const current = currentElement[id];
-      const next = renderArticleJson({ items: nextProps.items });
-      nextElement[id] = next;
-      const itemsHasUpdated = props.items !== nextProps.items;
-      const htmlHasUpdated = itemsHasUpdated && next.innerHTML !== current.innerHTML;
 
-      return htmlHasUpdated ||
+      const itemsHasUpdated = props.items !== nextProps.items;
+      if (itemsHasUpdated) {
+        const next = renderArticleJson({ items: nextProps.items });
+        nextElement[id] = next;
+      }
+
+      return itemsHasUpdated ||
         props.selections !== nextProps.selections ||
         props.contenteditable !== nextProps.contenteditable;
     },
@@ -104,7 +106,9 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
       assert(oldArticleElm, 'oldArticleElm must exists');
       assert(newArticleElm, 'newArticleElm must exists');
 
-      patchDom({oldArticleElm, newArticleElm});
+      if (oldArticleElm.innerHTML !== newArticleElm.innerHTML) {
+        patchDom({oldArticleElm, newArticleElm});
+      }
 
       if (selections) {
         restoreSelection(oldArticleElm);

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,8 +87,6 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
       return <Article items={[]} articleProps={articleProps} />;
     },
     shouldUpdate: ({props, id}, nextProps) => {
-      const current = currentElement[id];
-
       const itemsHasUpdated = props.items !== nextProps.items;
       if (itemsHasUpdated) {
         const next = renderArticleJson({ items: nextProps.items });

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,10 +106,10 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
 
       if (oldArticleElm.innerHTML !== newArticleElm.innerHTML) {
         patchDom({oldArticleElm, newArticleElm});
-      }
 
-      if (selections) {
-        restoreSelection(oldArticleElm);
+        if (selections) {
+          restoreSelection(oldArticleElm);
+        }
       }
     }
   };


### PR DESCRIPTION
Type: Patch

When I added the check for if html has changed some of our customKeyDown handlers started to fail. Since the keydown event handler was only being re-attached when the html needed to be updated the customKeyDown event handlers that used the articleJson items array to determine what to do was sometimes failing because it didn't have access to the latest version of that array. This PR fixes that. 