### PR TITLE
Make sure selection mark tags are always cleaned up

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ import {map} from 'immutable-array-methods';
 import {setIn} from 'immutable-object-methods';
 import objectAssign from 'object-assign';
 import patchDom from './patch-dom';
+import {diffChars} from 'diff';
 
 function parseEmbed (type) {
   return (elm) => {
@@ -111,6 +112,12 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
       assert(newArticleElm, 'newArticleElm must exists');
 
       if (oldArticleElm.innerHTML !== newArticleElm.innerHTML) {
+        console.log('PATCHED:');
+        diffChars(oldArticleElm.innerHTML, newArticleElm.innerHTML).forEach((part) => {
+          if (part.added || part.removed) {
+            console.log(part.added ? 'added: ' : 'removed: ', part.value);
+          }
+        });
         patchDom({oldArticleElm, newArticleElm});
       }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,7 +111,6 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
       assert(newArticleElm, 'newArticleElm must exists');
 
       if (oldArticleElm.innerHTML !== newArticleElm.innerHTML) {
-        console.log('patch')
         patchDom({oldArticleElm, newArticleElm});
 
         if (selections) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,8 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
       assert(oldArticleElm, 'oldArticleElm must exists');
       assert(newArticleElm, 'newArticleElm must exists');
 
-      if (oldArticleElm.innerHTML !== removeSelectionTagsFromString(newArticleElm.innerHTML)) {
+      if (oldArticleElm.innerHTML !== newArticleElm.innerHTML) {
+        console.log('patch')
         patchDom({oldArticleElm, newArticleElm});
 
         if (selections) {
@@ -120,10 +121,6 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
     }
   };
 };
-
-function removeSelectionTagsFromString (html) {
-  return html.replace('<mark class="selection-start"></mark>', '').replace('<mark class="selection-end"></mark>', '');
-}
 
 function formatItems (item) {
   if (item.type === 'embed') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,10 +112,10 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
 
       if (oldArticleElm.innerHTML !== newArticleElm.innerHTML) {
         patchDom({oldArticleElm, newArticleElm});
+      }
 
-        if (selections) {
-          restoreSelection(oldArticleElm);
-        }
+      if (selections) {
+        restoreSelection(oldArticleElm);
       }
     }
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,6 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
           saveSelection(articleContainer);
         }
         const items = htmlToArticleJson(articleContainer);
-        removeSelectionTagsFromElement(articleContainer);
         onUpdate({items, selectionBoundingClientRect, activeItem});
       };
 
@@ -94,9 +93,15 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
         nextElement[id] = next;
       }
 
-      return itemsHasUpdated ||
+      const shouldUpdate = itemsHasUpdated ||
         props.selections !== nextProps.selections ||
         props.contenteditable !== nextProps.contenteditable;
+
+      if (!shouldUpdate) {
+        // To clean up selection mark tags
+        restoreSelection(currentElement[id]);
+      }
+      return shouldUpdate;
     },
     afterRender: ({props: {items, selections = true}, id}, oldArticleElm) => {
       currentElement[id] = oldArticleElm;
@@ -118,18 +123,6 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
 
 function removeSelectionTagsFromString (html) {
   return html.replace('<mark class="selection-start"></mark>', '').replace('<mark class="selection-end"></mark>', '');
-}
-
-function removeSelectionTagsFromElement (elm) {
-  const start = elm.querySelector('mark.selection-start');
-  const end = elm.querySelector('mark.selection-end');
-  if (start) {
-    start.parentNode.removeChild(start);
-  }
-
-  if (end) {
-    end.parentNode.removeChild(end);
-  }
 }
 
 function formatItems (item) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,6 +74,7 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
           saveSelection(articleContainer);
         }
         const items = htmlToArticleJson(articleContainer);
+        removeSelectionTagsFromElement(articleContainer);
         onUpdate({items, selectionBoundingClientRect, activeItem});
       };
 
@@ -104,7 +105,7 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
       assert(oldArticleElm, 'oldArticleElm must exists');
       assert(newArticleElm, 'newArticleElm must exists');
 
-      if (oldArticleElm.innerHTML !== newArticleElm.innerHTML) {
+      if (oldArticleElm.innerHTML !== removeSelectionTagsFromString(newArticleElm.innerHTML)) {
         patchDom({oldArticleElm, newArticleElm});
 
         if (selections) {
@@ -114,6 +115,22 @@ const setup = ({customTextFormattings, parseFigureProps, customCaption} = {}) =>
     }
   };
 };
+
+function removeSelectionTagsFromString (html) {
+  return html.replace('<mark class="selection-start"></mark>', '').replace('<mark class="selection-end"></mark>', '');
+}
+
+function removeSelectionTagsFromElement (elm) {
+  const start = elm.querySelector('mark.selection-start');
+  const end = elm.querySelector('mark.selection-end');
+  if (start) {
+    start.parentNode.removeChild(start);
+  }
+
+  if (end) {
+    end.parentNode.removeChild(end);
+  }
+}
 
 function formatItems (item) {
   if (item.type === 'embed') {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "article-json-html-render": "^2.5.0",
     "deku": "^1.0.0",
+    "diff": "^3.2.0",
     "dift": "^0.1.12",
     "embeds": "^2.5.1",
     "get-selection-range-from-elm": "^2.0.1",

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -329,6 +329,7 @@ if (process.browser) {
         markClass: 'selection-end'
       }]
     }];
+
     const app = tree(<ArticleJsonToContenteditable items={initialItems} onUpdate={onUpdate}/>);
     const container = renderAppInContainer(app);
     const secondParagraph = container.querySelectorAll('article p')[1];
@@ -337,15 +338,24 @@ if (process.browser) {
     function onUpdate ({items}) {
       onUpdateCalled = true;
       t.deepEqual(items, expected);
-      t.is(container.querySelector('mark.selection-start'), null, 'No selection tag in dom');
-      t.is(container.querySelector('mark.selection-end'), null, 'No selection tag in dom');
     }
+
+    t.is(container.querySelector('mark.selection-start'), null, 'No selection tag in dom after render');
+    t.is(container.querySelector('mark.selection-end'), null, 'No selection tag in dom after render');
 
     setSelection(secondParagraph, 0, secondParagraph, 1);
     container.querySelector('article').dispatchEvent(mouseup());
     t.ok(onUpdateCalled, 'onUpdate was called');
-    app.unmount();
-    t.end();
+
+    app.mount(<ArticleJsonToContenteditable items={initialItems} onUpdate={onUpdate}/>);
+
+    process.nextTick(() => {
+      t.is(container.querySelector('mark.selection-start'), null, 'No selection tag in dom after update');
+      t.is(container.querySelector('mark.selection-end'), null, 'No selection tag in dom after update');
+
+      app.unmount();
+      t.end();
+    });
   });
 
   test('<ArticleJsonToContenteditable> no saved selections on blur', t => {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -337,6 +337,8 @@ if (process.browser) {
     function onUpdate ({items}) {
       onUpdateCalled = true;
       t.deepEqual(items, expected);
+      t.is(container.querySelector('mark.selection-start'), null, 'No selection tag in dom');
+      t.is(container.querySelector('mark.selection-end'), null, 'No selection tag in dom');
     }
 
     setSelection(secondParagraph, 0, secondParagraph, 1);


### PR DESCRIPTION
Make sure selection mark tags are not left in dom. With the performance updates we've done lately, selection mark tags have unintentionally been left in the dom between updates even though that's not needed. They are only needed when parsing html to article json and after patching dom in afterRender. 

Also had to update the html equality check in afterRender to strip those tags out of the newly created article html. 